### PR TITLE
Add simple AI chat front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# AI_Chat
+# AI Chat
+
+Simple front-end page to chat with an AI model using OpenAI's API.
+
+## Usage
+
+1. Open `index.html` in your browser.
+2. Enter your OpenAI API key in the input field.
+3. Ask a question and click **Send** to see the AI's response.

--- a/chat.js
+++ b/chat.js
@@ -1,0 +1,48 @@
+const chat = document.getElementById('chat');
+const userInput = document.getElementById('userInput');
+const sendBtn = document.getElementById('sendBtn');
+
+function appendMessage(sender, text) {
+  const p = document.createElement('p');
+  p.textContent = `${sender}: ${text}`;
+  chat.appendChild(p);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+async function sendMessage() {
+  const apiKey = document.getElementById('apiKey').value.trim();
+  const question = userInput.value.trim();
+  if (!apiKey || !question) {
+    return;
+  }
+
+  appendMessage('You', question);
+  userInput.value = '';
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: question }]
+      })
+    });
+
+    const data = await response.json();
+    const answer = data.choices?.[0]?.message?.content?.trim() || 'No response';
+    appendMessage('AI', answer);
+  } catch (error) {
+    appendMessage('Error', error.message);
+  }
+}
+
+sendBtn.addEventListener('click', sendMessage);
+userInput.addEventListener('keyup', (e) => {
+  if (e.key === 'Enter') {
+    sendMessage();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 2rem;
+    }
+    #chat {
+      border: 1px solid #ccc;
+      height: 300px;
+      overflow-y: auto;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    #chat p {
+      margin: 0.5rem 0;
+    }
+    #controls {
+      display: flex;
+      gap: 0.5rem;
+    }
+    #userInput {
+      flex: 1;
+    }
+  </style>
+</head>
+<body>
+  <h1>AI Chat</h1>
+  <div>
+    <label>API Key: <input type="password" id="apiKey" placeholder="OpenAI API key" /></label>
+  </div>
+  <div id="chat"></div>
+  <div id="controls">
+    <input id="userInput" type="text" placeholder="Ask a question..." />
+    <button id="sendBtn">Send</button>
+  </div>
+  <script src="chat.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create a minimal HTML page with input fields and chat display for interacting with an AI model
- Add JavaScript logic to send user questions to OpenAI's chat completion API and show responses
- Document how to use the front-end to ask questions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f927b04988328ac1532045e4f158d